### PR TITLE
fixed broadcasting issue between y and y_pred in PopStats

### DIFF
--- a/PopStats/loader.py
+++ b/PopStats/loader.py
@@ -19,7 +19,7 @@ class DataIterator(object):
             self.X = f['X'][()]
             self.d = self.X.shape[0]
             self.X = np.reshape(self.X.transpose(), [-1,self.N,self.d]).astype('float32')
-            self.y = np.squeeze(f['Y'][()]).astype('float32')
+            self.y = np.reshape(f['Y'][()],[-1,1]).astype('float32')
             #self.y = 3*(self.y + 74.74)
         
         assert len(self.y) >= self.batch_size, \


### PR DESCRIPTION
Before this fix, the (128,)-tensor `y` behaves as a (1,128)-tensor when subtracted from the (128,1)-tensor `y_pred`, yielding a (128,128)-tensor, which leads to the wrong MSE-loss. Before this fix
 the model approximates the average statistic across the indices instead of the corresponding statistic for each index.

Before:
![current_status](https://user-images.githubusercontent.com/50104235/62137088-a52dae00-b2e5-11e9-8a2f-ecbf646e5065.png)

After:
![current_status](https://user-images.githubusercontent.com/50104235/62136956-6a2b7a80-b2e5-11e9-9d6b-d56a2bde9567.png)